### PR TITLE
Fix opened event

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,7 @@ class CommandPal {
     function subTo(eventName) {
       ctx.app.$on(eventName, (e) => ctx.ps.publish(eventName, e.detail));
     }
-    subTo("open");
+    subTo("opened");
     subTo("closed");
     subTo("textChanged");
     subTo("exec");


### PR DESCRIPTION
Was messing around with this and noticed the `opened` event wasn't firing for some reason. This did the trick for me. 

Great drop-in utility, thanks!