### PR TITLE
Add custom placeholder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ c.start();
 ``` js
 const c = new CommandPal({
   hotkey: "ctrl+space",
+  placeholder: "Custom placeholder text...",
   commands: [
     {
       name: "Change Language",
@@ -129,6 +130,7 @@ c.start();
 const c = new CommandPal({
   hotkey: "ctrl+space",  // Launcher shortcut
   hotkeysGlobal: true,       // Makes shortcut keys work in any <textarea>, <input> or <select>
+  placeholder: "Custom placeholder text...", //  Changes placeholder text of input
   commands: [
     // Commands go here
   ]

--- a/public/cp-advanced/index.html
+++ b/public/cp-advanced/index.html
@@ -62,6 +62,7 @@
     <script>
       const c = new CommandPal({
         hotkey: "ctrl+space",
+        placeholder: "Custom placeholder text...",
         commands: [
           {
             name: "Toggle Dark/Light Theme",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -16,6 +16,7 @@
   export let hotkey;
   export let inputData = [];
   export let hotkeysGlobal;
+  export let placeholderText;
 
   const optionsFuse = {
     isCaseSensitive: false,
@@ -140,6 +141,7 @@
   <PaletteContainer bind:show={showModal}>
     <div slot="search">
       <SearchField
+        placeholderText={placeholderText}
         show={showModal}
         bind:inputEl={searchField}
         on:closed={onClosed}

--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -5,6 +5,7 @@
 
   export let show;
   export let inputEl;
+  export let placeholderText;
 
   let inputValue;
 
@@ -74,4 +75,4 @@
   on:input={onTextChanged}
   autocomplete="no"
   type="text"
-  placeholder="What are you looking for?" />
+  placeholder={placeholderText} />

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ class CommandPal {
       props: {
         hotkey: this.options.hotkey || 'ctrl+space',
         inputData: this.options.commands || [],
+        placeholderText: this.options.placeholder || "What are you looking for?",
         hotkeysGlobal: this.options.hotkeysGlobal || false
       },
     });


### PR DESCRIPTION
This adds the option `placeholder`, which allows the consumer to add custom placeholder text to the command palette.

Fixes #10