### PR TITLE
Scale size of command list to available height; contain overscroll

### DIFF
--- a/src/CommandList.svelte
+++ b/src/CommandList.svelte
@@ -72,7 +72,9 @@
   }
   .items-list {
     overflow-y: auto;
-    max-height: 360px;
+    max-height: min(360px, 50vh);
+    max-height: min(360px, 80dvh);
+    overscroll-behavior: contain;
   }
   .no-matches {
     margin: 5px 0px;


### PR DESCRIPTION
The current code limits listbox (.items-list) height to 360px. On mobile devices the soft keyboard can take up a good portion of the viewport making it impossible to scroll to the end of the list (it's hidden under the keyboard).

Change the listbox height to the minimum of 360px or 45vh (45% of viewport height) or 80dvh (80% of viewport height which does not include the height of the browser controls). These aee not 100% due to the height of the search box and because dvh on mobile firefox doesn't seem to change if the firefox controls are displayed by scrolling.

Also when scrolling to the end of the list, stop scrolling the underlying page.

Note the underlying page can still be scrolled by scrolling gestures on the backdrop. this could be undesirable, but is not addressed here.