### PR TITLE
Fix hotkeysGobal to work in input/textarea/select/checkbox

### DIFF
--- a/public/cp-advanced/index.html
+++ b/public/cp-advanced/index.html
@@ -44,6 +44,15 @@
       <p>Or</p>
       <p class="is-flex">Click the <img style="margin-bottom: -5px;" src="https://i.imgur.com/rLU7EJN.png" /> icon on the bottom left </p>
     </center>
+    <input autofocus type="text">
+    <input type="checkbox">
+    <textarea>here is some text</textarea>
+    <select>
+      <option>foo</option>
+      <option>foo</option>
+      <option>foo</option>
+    </select>
+
     <h2>Output</h2>
     <pre id="output">try it out...</pre>
     <details>
@@ -62,6 +71,7 @@
     <script>
       const c = new CommandPal({
         hotkey: "ctrl+space",
+        hotkeysGlobal: true,  
         placeholder: "Custom placeholder text...",
         commands: [
           {

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -6,11 +6,12 @@ export function initShortCuts(bindToInputsToo) {
   if (bindToInputsToo) {
     /* 
     Allows binding to input, select and textarea
-    https://stackoverflow.com/questions/59855852/input-blocks-hotkeys 
+    https://stackoverflow.com/questions/59855852/input-blocks-hotkeys
+    Appears to not work. Setting scope to "all" does work. // rouilj
     */
     hotkeys.filter = function(event){
       var tagName = (event.target || event.srcElement).tagName;
-      hotkeys.setScope(/^(INPUT|TEXTAREA|SELECT)$/.test(tagName) ? 'input' : 'other');
+      hotkeys.setScope('all');
       return true;
     }
   }


### PR DESCRIPTION
Setting hotkeysGlobal didn't allow ctrl+space or any other hotkey to work while I was focused on an input.

The documentation for scopes in hotkey.js wasn't clear. After trying to work through the code with the debugger I was none the wiser. How are scopes supposed to be used and why do they exist?

I simply changed the call to: hotkeys.setScope("all"). I don't know if this will cause issues, but I changed cp-advanced/index.html to have the 4 input types for testing and I didn't see any issues. ctrl+space plus ctrl+1 worked to activate the command palette and toggle the theme.

Given the static value for setScope, you can probably remove the tagName setting as well. However, this is all dark code for me so ....