### PR TITLE
add an option noButton to disable the mobile button

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ const c = new CommandPal({
   hotkey: "ctrl+space",  // Launcher shortcut
   hotkeysGlobal: true,       // Makes shortcut keys work in any <textarea>, <input> or <select>
   placeholder: "Custom placeholder text...", //  Changes placeholder text of input
+  noButton: false, // if true, do not generate mobile button
+
   commands: [
     // Commands go here
   ]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
   export let inputData = [];
   export let hotkeysGlobal;
   export let placeholderText;
+  export let noButton;
 
   const optionsFuse = {
     isCaseSensitive: false,
@@ -137,7 +138,9 @@
 </script>
 
 <div>
-  <MobileButton on:click={onMobileClick} />
+  { #if noButton == false }
+    <MobileButton on:click={onMobileClick} />
+  {/if}
   <PaletteContainer bind:show={showModal}>
     <div slot="search">
       <SearchField

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,8 @@ class CommandPal {
         hotkey: this.options.hotkey || 'ctrl+space',
         inputData: this.options.commands || [],
         placeholderText: this.options.placeholder || "What are you looking for?",
-        hotkeysGlobal: this.options.hotkeysGlobal || false
+        hotkeysGlobal: this.options.hotkeysGlobal || false,
+        noButton: this.options.noButton || false,
       },
     });
     const ctx = this;


### PR DESCRIPTION
The button isn't really that useful if you are on a desktop system. The shortcut key is easily accessible and the button is just clutter. So add an option to suppress the mobile button when starting up command-pal.

This could also be useful if you have multiple command palettes. The main one has a command button and other ones are invoked from the main one or via their own hotkey. (I am not sure that this would work but...).

Side note, modifying the CSS via JavaScript to include:

   button.mobile-button { display: none; }

possibly with a `!important` will also hide the button. This option prevents the HTML for the button from being generated.