### PR TITLE
disable debug output unless new option debugOutput set to truthy value

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ const c = new CommandPal({
   hotkey: "ctrl+space",  // Launcher shortcut
   hotkeysGlobal: true,       // Makes shortcut keys work in any <textarea>, <input> or <select>
   placeholder: "Custom placeholder text...", //  Changes placeholder text of input
+  debugOuput: false, // if true report debugging info to console
   commands: [
     // Commands go here
   ]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
   export let inputData = [];
   export let hotkeysGlobal;
   export let placeholderText;
+  export let debugOutput;
 
   const optionsFuse = {
     isCaseSensitive: false,

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import pubsub from "micro-pubsub";
 
 class CommandPal {
   constructor(options) {
-    console.log("CommandPal", { options });
+    if (options.debugOutput) { console.log("CommandPal", { options });}
     this.options = options || {};
     this.ps = pubsub.create();
   }
@@ -15,7 +15,8 @@ class CommandPal {
         hotkey: this.options.hotkey || 'ctrl+space',
         inputData: this.options.commands || [],
         placeholderText: this.options.placeholder || "What are you looking for?",
-        hotkeysGlobal: this.options.hotkeysGlobal || false
+        hotkeysGlobal: this.options.hotkeysGlobal || false,
+        debugOutput: this.options.debugOutput || false,
       },
     });
     const ctx = this;


### PR DESCRIPTION
New option debugOutput if set to a truthy value will enable the console.log statement. This cleans up the console when in production.