### PR TITLE
add option to log hashes of svelte style blocks (needs svelte patch too)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ const c = new CommandPal({
   hotkey: "ctrl+space",  // Launcher shortcut
   hotkeysGlobal: true,       // Makes shortcut keys work in any <textarea>, <input> or <select>
   placeholder: "Custom placeholder text...", //  Changes placeholder text of input
+  reportStyleHash: false // if true, report the id and sha256 hashes
+                         // of the svelt inlined style blocks. The hashes
+                         // can be added to the CSP (Content Security Policy)
+                         // style-src or default-src if your app uses them.
+                         // Requires a modified svelt/internal/index.mjs
+                         // append() function.
   commands: [
     // Commands go here
   ]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
   export let inputData = [];
   export let hotkeysGlobal;
   export let placeholderText;
+  export let reportStyleHash;
 
   const optionsFuse = {
     isCaseSensitive: false,

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,22 @@ class CommandPal {
     console.log("CommandPal", { options });
     this.options = options || {};
     this.ps = pubsub.create();
+
+    // if function already defined follow the Beatles and Let It Be
+    if (typeof(window.cp_hashFromString) === 'undefined') {
+      if ( ! this.options.reportStyleHash ) {
+	window.cp_hashFromString = async function (name, string) {return null}
+      } else {
+	window.cp_hashFromString = async function (name, string) {
+	  const hash = await crypto.subtle.digest(
+	    "SHA-256",
+	    (new TextEncoder()).encode(string))
+	  let csp = "sha256-" + btoa(String.fromCharCode(
+	    ...new Uint8Array(hash)));
+	  return `${name} '${csp}'`;
+	}
+      }
+    }
   }
 
   start() {
@@ -15,7 +31,8 @@ class CommandPal {
         hotkey: this.options.hotkey || 'ctrl+space',
         inputData: this.options.commands || [],
         placeholderText: this.options.placeholder || "What are you looking for?",
-        hotkeysGlobal: this.options.hotkeysGlobal || false
+        hotkeysGlobal: this.options.hotkeysGlobal || false,
+        reportStyleHash: this.options.reportStyleHash || false
       },
     });
     const ctx = this;


### PR DESCRIPTION
When command-pal runs, svelte inject style blocks into the page. These style blocks will not be applied if you use Content Security Policies (CSP) to secure your web application. To allow them to be applied, you need to add hashes for the style blocks to the style-src (or default-src) CSP settings.

This patch adds a reportStyleHash option to CommandPal. This along with a modification to the append() function in the node module svelte/internal/index.mjs results in console.log
output like:

  svelte-1qhguwm-style 'sha256-gwaXl9ypsP5M+Pl7IPC4TdkehJgQRvkKmcYSf6NCydU='
  svelte-bvn01s-style 'sha256-uBf9jI60SnIb3YTm/PeNRoEUOwpLyiOgSOmdm9XR8v8='
  svelte-1ary9cc-style 'sha256-RpNJcpPx5tmGIdPUg0nsHLh99/fW3Gh85m5Kr+izRG8='
  svelte-zz386-style 'sha256-flay8qiGrAOgKV+HMGAUkHtP0Ff+D+FyO2PBYlnYM78='

where the second element is the hash and the first element is the id for the injected style block. The hashes (including the ') can be copied into a CSP string.

You should calculate these for your copy of the command-pal JavaScript library. They should remain the same as long as the library isn't updated.

To make this work also requires a change be made to a node-module used to build command-pal.

The file node-modules/svelte/internal/index.mjs needs a modified definition of the append() function. Modify the append function by inserting:

    if ( node.tagName === "STYLE") {
      cp_hashFromString(node.id, node.innerText).then(
        function (value) {if (value) { console.log(value) }}
      )
    }

at the beginning of the function.

This patch includes two versions of cp_hashFromString. It will use it's internal definitions only if cp_hashFromString is undefined. If window.cp_hashFromString collides with a different function or something that is not a function, you will get an error and CommandPal will not work.

If reportStyleHash is set to false (default), the version that is used just returns null.  This suppresses console output. If reportStyleHash is set to truthy it invokes a version from
https://stackoverflow.com/a/69486709 to return the base64 encoded sha256 hash for the style. When the browser calculates the sha256 hash for the injected style it sees that it matches a sha256 in the CSP header and applies the style block.

You can also define a cp_hashFromString in script tag in your web page before invoking CommandPal. In this case, your version will be used so you could generate sha512 hashes if you wanted.

Note this is a hack. There should be some way to externalize the injected style blocks so they can be included using <style nonce="...">. This would eliminate the need to update the CSP with each new CommandPal release. But I am only smart enough to work around it this way.

See #13 for more details.