### PR TITLE
Add support for adding icons to the CommandList.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ c.subscribe("closed", (e) => { console.log("closed", { e }); });
   name: "Open Messages",
   // Required name of command (displayed)
   description: "View all messages in inbox",
+  // HTML string to display an icon e.g. for </>
+  icon: "<span class="icon">&lt;/&gt;</span>",
   // Shortcut of command
   shortcut: "ctrl+3",
   // Callback function of the command to execute
@@ -173,6 +175,32 @@ c.subscribe("closed", (e) => { console.log("closed", { e }); });
   children: [...]
 },
 ```
+
+#### Adding Icons
+
+The `icon` property is interpreted as HTML and used as a 24x24 icon to
+the left of the menu item.
+
+If the icon property is not provided, an empty svg will be
+generated. This keeps the commands aligned when only some commands
+have icons. To remove/hide the empty svg, add `svg.cp-placeholder {
+display: none; }` to your CSS. This will move all commands without an
+icon property flush to the left of the list box.
+
+The icon property can be set to `null`. In this case, no placeholder
+icon will be generated. This will move the command flush to the left
+of the list box.
+
+If the icon property is set to a string, it is inserted as is into the
+list box. You can insert characters as the icon (make sure to use
+entities for characters like `<`).  Use `&nbsp;` to left pad the
+character strings as needed. You should wrap the string in `<span
+class="icon">` and `</span>` tags. This truncates the string at 24px
+matching alignment with svg or img icons.
+
+You can also include an `svg` or an `img` tag. For svg tags, you may
+want to use CSS styling to set the `fill` property to `currentcolor`
+so the svg strokes match the text color.
 
 ### Command Item Child
 

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.2",
-    "serve": "^11.3.2",
-    "svelte": "^3.0.0"
+    "serve": "^11.3.2"
   },
   "dependencies": {
-    "fuse.js": "^5.2.3",
+    "fuse.js": "^6.6.2",
     "hotkeys-js": "^3.7.6",
-    "micro-pubsub": "1.0.0"
+    "micro-pubsub": "1.0.0",
+    "svelte": "^3.55.1"
   }
 }

--- a/src/CommandList.svelte
+++ b/src/CommandList.svelte
@@ -61,7 +61,8 @@
     justify-content: space-between;
     margin: 0px;
     padding: 0px 7px;
-    height: 36px;
+    min-height: 36px;
+    overflow-y: hidden;
   }
   .item:hover {
     cursor: pointer;
@@ -69,18 +70,24 @@
   .item span {
     flex-grow: 1;
   }
+  .item :first-child {
+    flex-shrink: 0;
+  }	     
   .item :global(img) {
+    flex-shrink: 0;
     height:24px;
     width:24px;
   }
   .item :global(span.icon) {
     display: inline-block;
+    flex-shrink: 0;	
     overflow: hidden;
     white-space: nowrap;
     width: 24px;
   }
   .item :global(svg) {
     fill: currentcolor;
+    flex-shrink: 0;
     height: 24px;
     width: 24px;
   }

--- a/src/CommandList.svelte
+++ b/src/CommandList.svelte
@@ -70,9 +70,6 @@
   .item span {
     flex-grow: 1;
   }
-  .item :first-child {
-    flex-shrink: 0;
-  }	     
   .item :global(img) {
     flex-shrink: 0;
     height:24px;

--- a/src/CommandList.svelte
+++ b/src/CommandList.svelte
@@ -67,7 +67,7 @@
   .item:hover {
     cursor: pointer;
   }
-  .item span {
+  .item span.command {
     flex-grow: 1;
   }
   .item :global(img) {
@@ -119,11 +119,11 @@
             <svg fill="#000000" class="cp-placeholder" height="24" width="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"></svg>
         {/if}
       {/if}
-      <span>{item.name}</span>
+      <span class="command">{item.name}</span>
       {#if !!item.shortcut}
         <kyb>{item.shortcut}</kyb>
       {:else}
-        <span />
+        <span class="cp-placeholder"/>
       {/if}
     </p>
   {/each}

--- a/src/CommandList.svelte
+++ b/src/CommandList.svelte
@@ -56,6 +56,7 @@
 <style>
   .item {
     display: flex;
+    gap: 0.5em;
     align-items: center;
     justify-content: space-between;
     margin: 0px;
@@ -64,6 +65,24 @@
   }
   .item:hover {
     cursor: pointer;
+  }
+  .item span {
+    flex-grow: 1;
+  }
+  .item :global(img) {
+    height:24px;
+    width:24px;
+  }
+  .item :global(span.icon) {
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 24px;
+  }
+  .item :global(svg) {
+    fill: currentcolor;
+    height: 24px;
+    width: 24px;
   }
   kyb {
     padding: 1px 4px;
@@ -89,6 +108,13 @@
       class="item"
       class:selected={index == selectedIndex}
       on:mousedown={e => clickedIndex(e, index)}>
+      {#if item.icon}
+        {@html item.icon}
+      {:else}
+	{#if item.icon !== null}
+            <svg fill="#000000" height="24" width="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"></svg>
+        {/if}
+      {/if}
       <span>{item.name}</span>
       {#if !!item.shortcut}
         <kyb>{item.shortcut}</kyb>

--- a/src/CommandList.svelte
+++ b/src/CommandList.svelte
@@ -108,11 +108,11 @@
       class="item"
       class:selected={index == selectedIndex}
       on:mousedown={e => clickedIndex(e, index)}>
-      {#if item.icon}
+      {#if !!item.icon}
         {@html item.icon}
       {:else}
 	{#if item.icon !== null}
-            <svg fill="#000000" height="24" width="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"></svg>
+            <svg fill="#000000" class="cp-placeholder" height="24" width="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"></svg>
         {/if}
       {/if}
       <span>{item.name}</span>


### PR DESCRIPTION
This adds support for placing icons to the left of the commands.

5 cases are supported:

  1. if icon is not defined, it inserts an empty svg that holds 24px of space on the left of the label

  2. if icon is null, the space is not held and the label smooshes to the left

  3. if icon is a character (in span class="icon"), the character is used. If the string is longer than 24 px, it's cut off.

  4. the icon can be an image, css sized to 24x24px.

  5. the icon can be an svg, css sized to 24x24px fill set to currentColor.

in each case the icon is a string "<img ...>" "<svg ...>...</svg>" etc see:

   https://github.com/benwinding/command-pal/issues/22

for details and examples