### PR TITLE
add feature to ignore blur event when debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ Then the following link:
 
 - http://localhost:5005/cp-advanced/local-dev.html
 
+When the search input loses focus (receives a blur event), the palette
+closes. This makes inspecting the palette using the browser's DevTools
+difficult, as switching to DevTools causes the focus to be lost. It is
+possible to stop the palette from closing when focus is lost. If you
+set `window.commandPalIgnoreBlur = true;` using the console, or in
+your JavaScript, it will stop the palette from closing.  To close the
+command palette, click/focus on the search input and type the `ESC`
+key. Running `delete(window.commandPalIgnoreBlur);` in the DevTools
+console will restore the normal close palette action.
+
 Have a go, PR's and issues always welcome.
 
 ## Prior Art

--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -20,6 +20,11 @@
     inputValue = "";
   }
 
+  function onFieldBlur() {
+    if (window.commandPalIgnoreBlur) return;
+    onBlur();
+  }
+
   function onKeyDown(e) {
     const keyCode = e.code.toLowerCase();
     if (keyCode === "enter") {
@@ -71,7 +76,7 @@
   bind:value={inputValue}
   id={inputName}
   name={inputName}
-  on:blur={onBlur}
+  on:blur={onFieldBlur}
   on:keydown={onKeyDown}
   on:input={onTextChanged}
   autocomplete="no"


### PR DESCRIPTION
If the command palette is open, switching to devtools closes the palette.  This makes debugging difficult. This adds the ability to ignore the blur event by setting window.commandPalIgnoreBlur = true in the devtools console or script block in an html page.

It's a dev only tool that I have found useful in debugging/enhancing command-pal.
