### PR TITLE
add HTML id's to selected elements to aid CSS styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ c.start();
 const c = new CommandPal({
   hotkey: "ctrl+space",  // Launcher shortcut
   hotkeysGlobal: true,       // Makes shortcut keys work in any <textarea>, <input> or <select>
+  paletteId: "CommandPalette", // adds unique ID to aid in targeting with CSS
   placeholder: "Custom placeholder text...", //  Changes placeholder text of input
   commands: [
     // Commands go here
@@ -215,6 +216,54 @@ const c = new CommandPal({
 });
 c.start();
 ```
+
+### Styling CommandPal instances
+
+The styles used by command-pal are included in the package, but you
+can override these. To make this easier, command-pal adds HTML id's to
+a few components.
+
+   * The whole palette is identified by `CommandPalette`.
+   * The mobile button inside `#CommandPalette` is identified by
+     `CommandPalette-button`.
+   * Lastly the mask/backdrop for the palette inside `#CommandPalette`
+     is identified by `CommandPalette-mask`.
+     
+The `CommandPalette` part of the id's can be set using the `paletteId`
+option to `CommandPal()`.
+
+Using this you can assign different backgrounds to different instances
+of command-pal. For example:
+```css
+  #mypal-button { top: 30px; bottom: auto;} 
+  #mypal-mask { background-color: rgb(255,255,0,0.75); }
+  #mypal [slot=items] { background-color: red}
+```
+along with:
+```
+   c = CommandPal(..., paletteId: 'mypal',)
+```
+
+will result in:
+
+   * the mobile button for the palette will be moved 30 pixels from
+     the top rather than 10px from the bottom.
+   * the backdrop will be yellow at 75% opacity rather than
+     black at 50% opacity.
+   * the background for the unselected/unhovered items on the command
+     list will be red.
+
+The `-button` and `-mask` ids are a shortcut. This is also valid:
+```css
+  /* mypal-button */
+  #mypal > button  { top: 30px; bottom: auto;}
+  /* mypal-mask */
+  #mypal > div.modal-mask { background-color: rgb(0,128,200,0.75); }
+  #mypal [slot=items] { background-color: yellow;}
+  #mypal .item {color:black;} /* color of text against yellow background */
+```
+but is more difficult to use and depends on the structure of the HTML
+more than using ids.
 
 ## Local Development
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
   export let inputData = [];
   export let hotkeysGlobal;
   export let placeholderText;
+  export let paletteId = "CommandPalette";
 
   const optionsFuse = {
     isCaseSensitive: false,
@@ -136,9 +137,9 @@
   }
 </script>
 
-<div>
-  <MobileButton on:click={onMobileClick} />
-  <PaletteContainer bind:show={showModal}>
+<div id={paletteId}>
+  <MobileButton on:click={onMobileClick} bind:paletteId={paletteId} />
+  <PaletteContainer bind:show={showModal} bind:paletteId={paletteId}>
     <div slot="search">
       <SearchField
         placeholderText={placeholderText}

--- a/src/MobileButton.svelte
+++ b/src/MobileButton.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher } from "svelte";
   const dispatch = createEventDispatcher();
+  export let paletteId;
 </script>
 
 <style>
@@ -34,7 +35,7 @@
   }
 </style>
 
-<button class="mobile-button" on:click={e => dispatch('click')} title="Click here to open command palette">
+<button class="mobile-button" on:click={e => dispatch('click')} title="Click here to open command palette" id={paletteId + "-button"}>
   <svg
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/PaletteContainer.svelte
+++ b/src/PaletteContainer.svelte
@@ -1,5 +1,6 @@
 <script>
   export let show = false;
+  export let paletteId;
 </script>
 
 <style>
@@ -47,7 +48,7 @@
 } */
 </style>
 
-<div class="modal-mask" class:hidden={!show}>
+<div class="modal-mask" class:hidden={!show} id={paletteId + "-mask"}>
   <div class="modal-wrapper">
     <div class="modal-container">
       <div class="search-box">

--- a/src/main.js
+++ b/src/main.js
@@ -13,9 +13,10 @@ class CommandPal {
       target: document.body,
       props: {
         hotkey: this.options.hotkey || 'ctrl+space',
+        hotkeysGlobal: this.options.hotkeysGlobal || false,
         inputData: this.options.commands || [],
+        paletteId: this.options.paletteId || "CommandPalette",
         placeholderText: this.options.placeholder || "What are you looking for?",
-        hotkeysGlobal: this.options.hotkeysGlobal || false
       },
     });
     const ctx = this;


### PR DESCRIPTION
Addresses #24. but it changes the id's a little and merges both proposed implementations.

The main div gets id `CommandPalette`, the mobile button gets `CommandPalette-button` and the modal-mask gets
`CommandPalette-mask`. Also a new option paletteId is created to change `CommandPalette` to something shorter 8-).

Doc included along with examples.