### PR TITLE
bug: using enter to select menu item now clears search box

### DIFF
--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -24,6 +24,7 @@
     const keyCode = e.code.toLowerCase();
     if (keyCode === "enter") {
       dispatch("enter", inputValue);
+      onBlur();
     } else if (keyCode === "arrowdown") {
       dispatch("arrowdown");
     } else if (keyCode === "arrowup") {


### PR DESCRIPTION
Type some characters to select a command and then type enter to execute it. The palette closes. When you re-open the palette, the search term you typed is still present and filtering the command list.

I expect the search term to be cleared similar to aborting with escape.

I am not sure if this is intentional or not, but I consider it a bug. I could be convinced it is a feature to allow power users to repeat the command by hitting return, open palette, hit return again etc. If so it needs to be documented as such.