### PR TITLE
add aliases search array and display best matches for aliases to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,7 @@ Also keep your aliases short when possible. Don't include terms in the
 alias that are already in the command. This helps prevent skewing of
 the scores (due to the same term being matched multiple times). It also
 keeps the command text size down making it more readable.
-
-Also this works for aliases made up of characters from the basic Latin
-alphabet. If they would be covered by the regular expression:
-`\w[\s\w-]*` it should work.
+Aliases in non-Latin languages should work.
 
 ### Command Item Child
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ const c = new CommandPal({
   hotkey: "ctrl+space",  // Launcher shortcut
   hotkeysGlobal: true,       // Makes shortcut keys work in any <textarea>, <input> or <select>
   placeholder: "Custom placeholder text...", //  Changes placeholder text of input
+  displayHints: false,  // if true, aliases are displayed as command hints
   commands: [
     // Commands go here
   ]
@@ -163,6 +164,8 @@ c.subscribe("closed", (e) => { console.log("closed", { e }); });
   name: "Open Messages",
   // Required name of command (displayed)
   description: "View all messages in inbox",
+  // Other names for the command that can be hints for the user
+  aliases: [ "View", "See" ],
   // Shortcut of command
   shortcut: "ctrl+3",
   // Callback function of the command to execute
@@ -173,6 +176,43 @@ c.subscribe("closed", (e) => { console.log("closed", { e }); });
   children: [...]
 },
 ```
+
+#### Aliases and Hints
+
+The aliases property is included by the fuzzy search. So searching for
+terms in the aliases array always works. Matches in the aliases array
+are weighted twice that of the name or description fields. However
+setting the `displayHints` option for `CommandPal` to `true` displays
+the best matching alias next to the command.
+
+For example suppose the `Open Messages` command has aliases of `See`
+and `View`. Typing `se` will display `Open Messages (See)` indicating
+that you should use the `Open Messages` command to see your messages.
+It helps explain what's being matched and why `Open Messages` is
+displayed when `see` is typed.  Similarly typing `vi` will produce
+`Open Messages (View)` in the command list. If you were to type `v`
+you would start with `Open Messages (View)` then typing `e` would
+result in `Open Messages (See)`. By default `displayHints` is
+disabled.
+
+The fuse.js fuzzy matcher returns match info. This indicates where it
+found matches to the search input.  This information is used to select
+the top hint to display to the user. For each match in the aliases
+array, the score is the count of the number of matching characters
+with a little extra weight given to matches at the beginning of the
+alias. If two terms have the same weight, the term more to the left in
+the array is chosen. To get the best use from this, order your terms
+putting the most used terms first in the array. This scoring method is
+a work in progress and may change in the future.
+
+Also keep your aliases short when possible. Don't include terms in the
+alias that are already in the command. This helps prevent skewing of
+the scores (due to the same term being matched multiple times). It also
+keeps the command text size down making it more readable.
+
+Also this works for aliases made up of characters from the basic Latin
+alphabet. If they would be covered by the regular expression:
+`\w[\s\w-]*` it should work.
 
 ### Command Item Child
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
-    "fuse.js": "^5.2.3",
+    "fuse.js": "^6.6.2",
     "hotkeys-js": "^3.7.6",
     "micro-pubsub": "1.0.0"
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -152,7 +152,7 @@
      * weighting factors that seem to work. Formula and number may
      * change.
     */
-    let match_metric = (a) => ( a.indices.map(
+    let match_metric = (indices) => ( indices.map(
       range => range[0] == 0 ?
 	((range[1] - range[0])
 	 * 2.5) + 1.5 :
@@ -160,8 +160,8 @@
      ).reduce((sum, val) => sum+val))
     
     const e = search_result.matches.filter(i => i.key === "aliases").sort((a,b) => {
-      let a_mm = match_metric(a)
-      let b_mm = match_metric(b)
+      let a_mm = match_metric(a.indices)
+      let b_mm = match_metric(b.indices)
       // match_metric describes number of matches characters current
       // search term matches. So the higher the better.
       // assume alias array referenced by refIndex has higher prio
@@ -193,7 +193,7 @@
       console.debug('hints', e.length)
       console.table(search_result.matches.filter( (i) => {
 	if (i.key === "aliases") {
-	  i.sum = match_metric(i);
+	  i.metric = match_metric(i.indices);
 	  return true;
 	}
 	return false;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,11 +17,23 @@
   export let inputData = [];
   export let hotkeysGlobal;
   export let placeholderText;
+  export let displayHints;
 
   const optionsFuse = {
     isCaseSensitive: false,
     shouldSort: true,
-    keys: ["name", "description"]
+    keys: ["name", "description", {name: "aliases", weight: 2}],
+    includeMatches: true,
+    sortFn: function (a,b) {
+      // This is the same stable sorting function supplied by fuse.
+      // Except we treat items with scores less than 0.05 apart as equal.
+      // This buckets similar commands together and makes the order of
+      // the commands in the commands array have more effect on filtered
+      // order. 0.05 is just a magic number that worked in testing, YMMV.
+      return ( Math.abs (a.score - b.score) < 0.05 ?
+	       (a.idx < b.idx ? -1 : 1) :
+	       a.score < b.score ? -1 : 1)
+    },
   };
 
   let showModal = false;
@@ -106,15 +118,68 @@
     }
   }
 
+  function removeHints(items) {
+    if (! displayHints ) return;
+    items.map( (i) => { if ( i.hinted ) {
+      i.name = i.name.replace(/ \(\w[\s\w-]*\)$/, '');
+      i.hinted = false
+    }})
+  }
+  
+  function hintMatch(i) {
+    // get a series of range matches for the characters. [0,0] indicates
+    // first char of term matched. So it counts for 1.5 point. [6,7]
+    // indicating 2 chars match counts for 2 points.
+    let match_index = (a) => ( a.indices.map(
+      range => range[0] == 0 ? range[1] - range[0] + 1.5:
+      	    range[1] - range[0] + 1).reduce((sum, val) => sum+val))
+    
+    const e = i.matches.filter(i => i.key === "aliases").sort((a,b) => {
+      let a_mi = match_index(a)
+      let b_mi = match_index(b)
+      // match_index describes number of matches characters current
+      // search term matches. So the higher the better.
+      // assume alias array referenced by refIndex has higher prio
+      // at lower indexes. So the lower the better.
+      return a_mi == b_mi? a.refIndex > b.refIndex : a_mi < b_mi
+    })
+    let hinted = !!i.item.hinted
+    if ( e.length ) {
+      /* add hints */
+      const hint = ` (${e[0].value})`
+      if (! hinted) {
+	i.item.name += hint
+      } else {
+	// re: space '(' alphanumeric_word_char
+	//            "0 or more word_char space char and -" ')'
+	//            end of line
+	// Note: this will not work for non-latin.
+	i.item.name = i.item.name.replace(/ \(\w[\s\w-]*\)$/, hint)
+      }
+      i.item.hinted = true
+    } else {
+      if (i.item.hinted) {
+	/* remove previous hints */
+	i.item.name = i.item.name.replace(/ \(\w[\s\w-]*\)$/, '')
+	i.item.hinted = false
+      }
+    }
+    return i.item
+  }
+
   function onTextChange(e) {
     const text = e.detail;
     dispatch("textChanged", text);
     selectedIndex = 0;
+
+    const processResult = displayHints ? hintMatch: (i) => i.item
+      
     if (!text) {
       itemsFiltered = items;
+      removeHints(itemsFiltered);
     } else {
       const fuseResult = fuse.search(text);
-      itemsFiltered = fuseResult.map(i => i.item);
+      itemsFiltered = fuseResult.map(processResult);
     }
   }
 
@@ -125,6 +190,7 @@
     }
     dispatch("closed");
     selectedIndex = 0;
+    removeHints(inputData);
     setItems(inputData);
     showModal = false;
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -37,29 +37,20 @@
   };
 
   if ( orderedCommands ) {
-    optionsFuse.sortFn = function (a,b) {
-      /* Sort results in two groups.  If scores of either item are
-         below 0.009 sort by score.  This prevents two items with
-         weights of 0.003 and 2.2E-16 from being bucketed and sorted
-         by order in the command array. If the value is low enough to
-         be a really good match, don't use the implicit order in the
-         commands array to override it.
+    optionsFuse.sortFn = function(a, b) {
+      const belowThreshold = a.score < 0.009 || b.score < 0.009;
+      const scoresAreEqual = a.score === b.score;
+      const scoresClose = Math.abs(a.score - b.score) < 0.05;
 
-         If both scores are larger than 0.009 and the difference
-         between them is < 0.05, bucket them together and sort the
-         items in the bucket by their original index location in the
-         commands array. In this case fuse.js isn't that certain about
-         the match and we order based on the position in the command
-         array that we have chosen to be most likely.
-
-         Note 0.009 and 0.05 are magic numbers that worked in testing, YMMV.
-      */
-      return ((a.score > 0.009 && b.score > 0.009) && // if scores > minimum
-              Math.abs (a.score - b.score) < 0.05 ?  // bucket them
-                (a.idx < b.idx ? -1 : 1) :  // sort by order in commands array
-                 (a.score == b.score ?  // else if scores equal
-                   (a.idx < b.idx ? -1 : 1) : // sort by index order
-                   a.score < b.score ? -1 : 1)) // else sort lowest score first
+      if (belowThreshold) {
+        return a.score < b.score ? -1 : 1;
+      } else if (scoresClose) {
+        return a.idx < b.idx ? -1 : 1;
+      } else if (scoresAreEqual) {
+        return a.idx < b.idx ? -1 : 1;
+      } else {
+        return a.score < b.score ? -1 : 1;
+      }
     }
     if (debugOutput) console.log('Using commands weighted sort');
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -31,6 +31,7 @@
     isCaseSensitive: false,
     shouldSort: true,
     keys: ["name", "description", {name: "aliases", weight: 2}],
+    includeScore: true,
     includeMatches: true,
     sortFn: function (a,b) {
       // This is the same stable sorting function supplied by fuse.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -204,7 +204,11 @@
       removeHints(itemsFiltered);
     } else {
       const fuseResult = fuse.search(text);
+      if (debugOutput && displayHints) console.groupCollapsed(
+        "CommandPal search: " + text)
       itemsFiltered = fuseResult.map(processResult);
+      if (debugOutput && displayHints) console.groupEnd(
+        "CommandPal search: " + text)
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -138,8 +138,11 @@
     // first char of term matched. So it counts for 1.5 point. [6,7]
     // indicating 2 chars match counts for 2 points.
     let match_index = (a) => ( a.indices.map(
-      range => range[0] == 0 ? range[1] - range[0] + 1.5:
-      	    range[1] - range[0] + 1).reduce((sum, val) => sum+val))
+      range => range[0] == 0 ?
+	((range[1] - range[0])
+	 * 2.5) + 1.5 :
+	((range[1] - range[0]) * 2.5) + 1
+     ).reduce((sum, val) => sum+val))
     
     const e = i.matches.filter(i => i.key === "aliases").sort((a,b) => {
       let a_mi = match_index(a)

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -159,15 +159,23 @@
 	((range[1] - range[0]) * 2.5) + 1
      ).reduce((sum, val) => sum+val))
     
-    const e = search_result.matches.filter(i => i.key === "aliases").sort((a,b) => {
-      let a_mm = match_metric(a.indices)
-      let b_mm = match_metric(b.indices)
-      // match_metric describes number of matches characters current
-      // search term matches. So the higher the better.
-      // assume alias array referenced by refIndex has higher prio
-      // at lower indexes. So the lower the better.
-      return a_mm == b_mm? a.refIndex > b.refIndex : a_mm < b_mm
-    })
+    const e = search_result.matches.filter(
+      i => i.key === "aliases").sort((a,b) => {
+	let a_mm = match_metric(a.indices)
+	let b_mm = match_metric(b.indices)
+
+	// a higher match_metric is assigned to a term that is a
+	// better match for the search.
+	// Sort by higher match_metric. If match_metrics are equal,
+	// sort the one with the lower index in the aliases array
+	// first. (Put the best choice aliases first.)
+	//    1 - sort b before a; -1 sort a before b.
+	// note: a.refIndex can never equal b.refIndex
+	return a_mm == b_mm ?
+      	  (a.refIndex < b.refIndex ? -1 : 1) :
+          ( a_mm > b_mm? -1 : 1)
+      })
+
     let hinted = !!search_result.item.hinted
     if ( e.length ) {
       /* add hints */

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -227,7 +227,7 @@
 	}
 	return false;
       }))
-      console.groupEnd("CommandPal " + item.name);
+      console.groupEnd();
     }
     return item
   }
@@ -247,8 +247,7 @@
       if (debugOutput && displayHints) console.groupCollapsed(
         "CommandPal search: " + text)
       itemsFiltered = fuseResult.map(processResult);
-      if (debugOutput && displayHints) console.groupEnd(
-        "CommandPal search: " + text)
+      if (debugOutput && displayHints) console.groupEnd()
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,13 @@
   export let placeholderText;
   export let displayHints;
 
+  // re: space '(' alphanumeric_word_char
+  //            "0 or more word_char space/tab and -" ')'
+  //            end of line
+  // Note: this should be the unicode equivalent of the Latin regexp:
+  //    / \(\w[\s\w-]*\)$/
+  let hintRegexp = / \([ \u0000-\u0019\u0021-\uFFFF_-]+\)$/u;
+
   const optionsFuse = {
     isCaseSensitive: false,
     shouldSort: true,
@@ -121,7 +128,7 @@
   function removeHints(items) {
     if (! displayHints ) return;
     items.map( (i) => { if ( i.hinted ) {
-      i.name = i.name.replace(/ \(\w[\s\w-]*\)$/, '');
+      i.name = i.name.replace(hintRegexp, '');
       i.hinted = false
     }})
   }
@@ -150,17 +157,13 @@
       if (! hinted) {
 	i.item.name += hint
       } else {
-	// re: space '(' alphanumeric_word_char
-	//            "0 or more word_char space char and -" ')'
-	//            end of line
-	// Note: this will not work for non-latin.
-	i.item.name = i.item.name.replace(/ \(\w[\s\w-]*\)$/, hint)
+	i.item.name = i.item.name.replace(hintRegexp, hint)
       }
       i.item.hinted = true
     } else {
       if (i.item.hinted) {
 	/* remove previous hints */
-	i.item.name = i.item.name.replace(/ \(\w[\s\w-]*\)$/, '')
+	i.item.name = i.item.name.replace(hintRegexp, '')
 	i.item.hinted = false
       }
     }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,6 +18,7 @@
   export let hotkeysGlobal;
   export let placeholderText;
   export let displayHints;
+  export let debugOutput;
 
   // re: space '(' alphanumeric_word_char
   //            "0 or more word_char space/tab and -" ')'
@@ -162,10 +163,6 @@
       if (! hinted) {
 	search_result.item.name += hint
       } else {
-	// re: space '(' alphanumeric_word_char
-	//            "0 or more word_char space char and -" ')'
-	//            end of line
-	// Note: this will not work for non-latin.
 	search_result.item.name = search_result.item.name.replace(hintRegexp, hint)
       }
       search_result.item.hinted = true
@@ -183,7 +180,7 @@
       console.debug('weight', search_result.item.weight)
       console.debug('hints', e.length)
       console.table(search_result.matches.filter( (i) => {
-	if (i.key ==="aliases") {
+	if (i.key === "aliases") {
 	  i.sum = match_index(i);
 	  return true;
 	}
@@ -192,7 +189,6 @@
       console.groupEnd("CommandPal " + search_result.item.name);
     }
     return search_result.item
->>>>>>> 222e59a (Add comments rename parameter i -> search_result)
   }
 
   function onTextChange(e) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -190,7 +190,7 @@
     } else {
       if (item.hinted) {
 	/* remove previous hints */
-	item.name = search_result.item.name.replace(hintRegexp, '')
+	item.name = item.name.replace(hintRegexp, '')
 	item.hinted = false
       }
     }
@@ -209,7 +209,7 @@
       }))
       console.groupEnd("CommandPal " + item.name);
     }
-    return search_result.item
+    return item
   }
 
   function onTextChange(e) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -176,28 +176,29 @@
           ( a_mm > b_mm? -1 : 1)
       })
 
-    let hinted = !!search_result.item.hinted
+    let item = search_result.item
+    let hinted = !!item.hinted
     if ( e.length ) {
       /* add hints */
       const hint = ` (${e[0].value})`
       if (! hinted) {
-	search_result.item.name += hint
+	item.name += hint
       } else {
-	search_result.item.name = search_result.item.name.replace(hintRegexp, hint)
+	item.name = item.name.replace(hintRegexp, hint)
       }
-      search_result.item.hinted = true
+      item.hinted = true
     } else {
-      if (search_result.item.hinted) {
+      if (item.hinted) {
 	/* remove previous hints */
-	search_result.item.name = search_result.item.name.replace(hintRegexp, '')
-	search_result.item.hinted = false
+	item.name = search_result.item.name.replace(hintRegexp, '')
+	item.hinted = false
       }
     }
     if (debugOutput) {
-      console.group("CommandPal " + search_result.item.name);
+      console.group("CommandPal " + item.name);
       console.debug('score', search_result.score)
       console.debug('index', search_result.refIndex)
-      console.debug('weight', search_result.item.weight)
+      console.debug('weight', item.weight)
       console.debug('hints', e.length)
       console.table(search_result.matches.filter( (i) => {
 	if (i.key === "aliases") {
@@ -206,7 +207,7 @@
 	}
 	return false;
       }))
-      console.groupEnd("CommandPal " + search_result.item.name);
+      console.groupEnd("CommandPal " + item.name);
     }
     return search_result.item
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -37,9 +37,10 @@
       // This buckets similar commands together and makes the order of
       // the commands in the commands array have more effect on filtered
       // order. 0.05 is just a magic number that worked in testing, YMMV.
+      // Note this never returns 0 because equal scores sort by order.
       return ( Math.abs (a.score - b.score) < 0.05 ?
-	       (a.idx < b.idx ? -1 : 1) :
-	       a.score < b.score ? -1 : 1)
+	       (a.idx < b.idx ? -1 : 1) :  // sort by order in commands array
+	       a.score < b.score ? -1 : 1) // sort by lowest score first
     },
   };
 
@@ -132,8 +133,9 @@
       i.hinted = false
     }})
   }
-  
-  function hintMatch(i) {
+
+  /** append best aliases match to command object's name */
+  function hintMatch(search_result) {
     // get a series of range matches for the characters. [0,0] indicates
     // first char of term matched. So it counts for 1.5 point. [6,7]
     // indicating 2 chars match counts for 2 points.
@@ -144,7 +146,7 @@
 	((range[1] - range[0]) * 2.5) + 1
      ).reduce((sum, val) => sum+val))
     
-    const e = i.matches.filter(i => i.key === "aliases").sort((a,b) => {
+    const e = search_result.matches.filter(i => i.key === "aliases").sort((a,b) => {
       let a_mi = match_index(a)
       let b_mi = match_index(b)
       // match_index describes number of matches characters current
@@ -153,24 +155,44 @@
       // at lower indexes. So the lower the better.
       return a_mi == b_mi? a.refIndex > b.refIndex : a_mi < b_mi
     })
-    let hinted = !!i.item.hinted
+    let hinted = !!search_result.item.hinted
     if ( e.length ) {
       /* add hints */
       const hint = ` (${e[0].value})`
       if (! hinted) {
-	i.item.name += hint
+	search_result.item.name += hint
       } else {
-	i.item.name = i.item.name.replace(hintRegexp, hint)
+	// re: space '(' alphanumeric_word_char
+	//            "0 or more word_char space char and -" ')'
+	//            end of line
+	// Note: this will not work for non-latin.
+	search_result.item.name = search_result.item.name.replace(hintRegexp, hint)
       }
-      i.item.hinted = true
+      search_result.item.hinted = true
     } else {
-      if (i.item.hinted) {
+      if (search_result.item.hinted) {
 	/* remove previous hints */
-	i.item.name = i.item.name.replace(hintRegexp, '')
-	i.item.hinted = false
+	search_result.item.name = search_result.item.name.replace(hintRegexp, '')
+	search_result.item.hinted = false
       }
     }
-    return i.item
+    if (debugOutput) {
+      console.group("CommandPal " + search_result.item.name);
+      console.debug('score', search_result.score)
+      console.debug('index', search_result.refIndex)
+      console.debug('weight', search_result.item.weight)
+      console.debug('hints', e.length)
+      console.table(search_result.matches.filter( (i) => {
+	if (i.key ==="aliases") {
+	  i.sum = match_index(i);
+	  return true;
+	}
+	return false;
+      }))
+      console.groupEnd("CommandPal " + search_result.item.name);
+    }
+    return search_result.item
+>>>>>>> 222e59a (Add comments rename parameter i -> search_result)
   }
 
   function onTextChange(e) {

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,9 @@ class CommandPal {
         inputData: this.options.commands || [],
         placeholderText: this.options.placeholder || "What are you looking for?",
         hotkeysGlobal: this.options.hotkeysGlobal || false,
-	displayHints: this.options.displayHints || false,
+        displayHints: this.options.displayHints || false,
+        orderedCommands: this.options.orderedCommands || false,
+        debugOutput: this.options.debugOutput || false,
       },
     });
     const ctx = this;

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,8 @@ class CommandPal {
         hotkey: this.options.hotkey || 'ctrl+space',
         inputData: this.options.commands || [],
         placeholderText: this.options.placeholder || "What are you looking for?",
-        hotkeysGlobal: this.options.hotkeysGlobal || false
+        hotkeysGlobal: this.options.hotkeysGlobal || false,
+	displayHints: this.options.displayHints || false,
       },
     });
     const ctx = this;


### PR DESCRIPTION
Note: This upgrades the required version of fuse.js to 6.6.2. This version allows weighting to be properly specified.

This adds an aliases array for each command. A match in the alias has a weight of 2x compared to the name or description fields. If the user enables the displayHints option, the best matching alias will be appended to the end of the command name. This is useful for listing alternate terms for the one that is chosen as the command name. For example:

  name: emacs, alias: editor

will show up as emacs (editor) if the user typed edit.

The README.md has more info.

This was inspired by the implementation of synonyms described at:

https://blog.superhuman.com/how-to-build-a-remarkable-command-palette/#rule-4-build-flexibility-into-your-command-palette