### PR TITLE
Include directions for closing command-pal when blur is disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ window.commandPalIgnoreBlur = true;
 // Re-enable
 window.commandPalIgnoreBlur = false;
 ```
+To close the palette. focus/select the search input and press the escape `ESC` key.
 
 Have a go, PR's and issues always welcome.
 


### PR DESCRIPTION
Your edit missed the directions on how to close an open palette when blur is disabled.