### PR TITLE
Restore focus to item that was focused before opening palette

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -45,6 +45,7 @@
       dispatch("opened");
     });
     setAllShortCuts(inputData, async command => {
+      focusedElement = document.activeElement
       showModal = true;
       dispatch("opened");
       await asyncTimeout(200);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,10 +34,12 @@
   let items = inputData;
   let itemsFiltered = inputData;
   let fuse = new Fuse(items, optionsFuse);
+  let focusedElement;
 
   onMount(() => {
     initShortCuts(hotkeysGlobal);
     setMainShortCut(hotkey, async () => {
+      focusedElement = document.activeElement
       showModal = true;
       selectedIndex = 0;
       dispatch("opened");
@@ -129,6 +131,7 @@
     selectedIndex = 0;
     setItems(inputData);
     showModal = false;
+    focusedElement.focus()
   }
 
   function onMobileClick(e) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -131,7 +131,11 @@
     selectedIndex = 0;
     setItems(inputData);
     showModal = false;
-    focusedElement.focus()
+    if ( ! focusedElement ) {
+      console.error("focusedElement not set")
+    } else {
+      focusedElement.focus()
+    }
   }
 
   function onMobileClick(e) {
@@ -139,11 +143,26 @@
     showModal = true;
     selectedIndex = 0;
   }
+
+  function onMobileFocus(e) {
+    /* Store the item that had focus and assign it to focusedElement.
+       This will allow us to set focus back to it when we exit. */
+
+    // Surprisingly event is defined and has the correct data
+    // even if I don't do this. But I'll explicity pass it via details.
+    // as having event magically defined scares me.
+    let event = e.detail;
+    if (event.relatedTarget && event.relatedTarget.focus) {
+       focusedElement = event.relatedTarget;
+    } else {
+      focusedElement = document.body
+    }
+  }
 </script>
 
 <div id={paletteId}>
   {#if !hideButton}
-    <MobileButton on:click={onMobileClick} />
+    <MobileButton on:click={onMobileClick} on:focus={onMobileFocus}/>
   {/if}
   <PaletteContainer bind:show={showModal}>
     <div slot="search">

--- a/src/MobileButton.svelte
+++ b/src/MobileButton.svelte
@@ -34,7 +34,9 @@
   }
 </style>
 
-<button class="mobile-button" on:click={e => dispatch('click')} title="Click here to open command palette">
+<button class="mobile-button" on:click={e => dispatch('click')}
+    on:focus={e=>dispatch('focus', e)}
+    title="Click here to open command palette.">
   <svg
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
When the palette opens, it steals focus from the underlying page. This change records the focused element before opening the modal. Then on onClose it restores the focus to the element.

This happens regardless of the state of hotkeysGlobal, but is only really noticeable when you invoke command-pal
from a control.
