### PR TITLE
Make hotkey toggle CommandPal on/off

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -41,6 +41,7 @@
       if (showModal) {
 	onClosed()
       } else {
+	focusedElement = document.activeElement
 	showModal = true;
 	selectedIndex = 0;
 	dispatch("opened");

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -38,9 +38,13 @@
   onMount(() => {
     initShortCuts(hotkeysGlobal);
     setMainShortCut(hotkey, async () => {
-      showModal = true;
-      selectedIndex = 0;
-      dispatch("opened");
+      if (showModal) {
+	onClosed()
+      } else {
+	showModal = true;
+	selectedIndex = 0;
+	dispatch("opened");
+      }
     });
     setAllShortCuts(inputData, async command => {
       showModal = true;

--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -77,6 +77,7 @@
   bind:value={inputValue}
   id={inputName}
   name={inputName}
+  data-id="cp-SearchField"
   on:blur={onFieldBlur}
   on:keydown={onKeyDown}
   on:input={onTextChanged}

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -3,15 +3,30 @@ import hotkeys from "hotkeys-js";
 export const asyncTimeout = ms => new Promise(res => setTimeout(res, ms));
 
 export function initShortCuts(bindToInputsToo) {
-  if (bindToInputsToo) {
-    /* 
-    Allows binding to input, select and textarea
-    https://stackoverflow.com/questions/59855852/input-blocks-hotkeys
-    Appears to not work. Setting scope to "all" does work. // rouilj
-    */
-    hotkeys.filter = function(event){
-      hotkeys.setScope('all');
-      return true;
+  // create a closure over bindToInputsToo
+  hotkeys.filter = function(event){
+    // no filtering
+    if ( bindToInputsToo ) { return true; }
+
+    // .matches supported by all major browsers in 2017
+    // document.activeElement.matches('[data-id=cp-SearchField]'
+    // Replaced with dataset supported 2015 and maybe faster?
+    if (document.activeElement.dataset['id'] === 'cp-SearchField' ) {
+      // allow hotkey to always work in command-pal search input
+      return true
+    } else {
+      // use hotkeys.js default filter rule
+      // https://github.com/jaywcjlove/hotkeys/issues/321
+      //   is not quite right: tagname = target.tagName not
+      //   tagname = target. Corrected below.
+      const target = event.target || event.srcElement;
+      const tagName = target.tagName;
+      // ignore: isContentEditable === 'true', <input> and
+      // <textarea> when readOnly state is false, <select>
+      return ! (target.isContentEditable ||
+		((tagName === 'INPUT' ||
+		  tagName === 'TEXTAREA' ||
+		  tagName === 'SELECT') && !target.readOnly))
     }
   }
 }


### PR DESCRIPTION
Make the hotkey able to toggle command pal on and dismiss it as well.

Inspired by

https://plutoapp.xyz/blog/post/designing-a-command-palette/#togglable

from: https://commandpalette.org

Basic reason is if a user accidentally hits it, they can hit it again to get out of it. Otherwise they have to figure out how to dismiss it.

Three changes:

1) add data-id=cp-SearchField to search input. When I first coded this
   it only worked with hotkeysGlobal: true. It would not work with
   hotkeysglobal: false.

   It finally dawned on me that the focus was in the search input when
   I sent the dismissal hotkey. hotkeys.js ignores hotkeys in an input
   by default. To fix this I had to find a way to uniquely identify
   this input to I could make hotkeys active. The normal id is a
   unique random string, so no joy there.

2) changed onMount to look at current state of showModal and call
   onClosed if true.

3) rewrote the hotkeys.js filter. Now I understand it. Wish I didn't
   8-).  When the filter function is defined, I make it a closure over
   BindToInputsToo. The new filter does 1 of three things:

      * if BindToInputsToo is true, it return true, so hotkeys will process it
      * if BindToInputsToo is false, check to see what the activeElement is. If its data-id is cp-SearchField return true so keys is processed. * otherwise look to see if it's a ContentEditable area, or a writable input or select. If so return false, else return true

Also I used https://github.com/jaywcjlove/hotkeys/issues/321 to figure out how to create a filter, it's not correct.

  tagname = target.tagName

not

  tagname = target

I don't know if that's why hotkeysGlobal didn't work originally.

Also the default scope is all. So no need to set it.

All that matters is that the filter returns true to process the key or false to ignore it. Setting the scope in the filter probably changes the lookup table used to find matching keys.