### PR TITLE
add footer to command-pal with configurable text

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ const c = new CommandPal({
   placeholder: "Custom placeholder text...", //  Changes placeholder text of input
   debugOuput: false, // if true report debugging info to console
   hideButton: false, // if true, do not generate mobile button
+  footerText: null,  // Text to display in the footer of the palette.
+                     // If null (default), do not add footer.
   commands: [
     // Commands go here
   ]
@@ -232,6 +234,10 @@ The styles used by command-pal are included in the package. However you can over
   #CommandPal [slot=items] { background-color: yellow;}
   /* item text */
   #CommandPal .item { color:black; }
+  /* footers (optional) in all command-pal instances */
+  .footer[slot=footer] { background-color: gold; color: black;}	
+  /* explicitly override footer styling for one instance */
+  #CommandPal .footer { background-color: gold; color: black;}
 ```
 
 You can also assign a custom `id` to the CommandPal instance.

--- a/public/cp-advanced/index.html
+++ b/public/cp-advanced/index.html
@@ -84,6 +84,7 @@
         hotkey: "ctrl+space",
         hotkeysGlobal: true,  
         placeholder: "Custom placeholder text...",
+        footerText: "Click background, press ESC key or ctrl+space to close.",
         commands: [
           {
             name: "Toggle Dark/Light Theme",

--- a/public/cp-advanced/local-dev.html
+++ b/public/cp-advanced/local-dev.html
@@ -68,6 +68,7 @@
       const c = new CommandPal({
         id: 'MyCommandPal',
         hotkey: "ctrl+space",
+        footerText: "Click background or press ESC key to close.",
         commands: [
           {
             name: "Toggle Dark/Light Theme",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,7 @@
   export let placeholderText;
   export let hideButton;
   export let paletteId;
+  export let footerText;
 
   const optionsFuse = {
     isCaseSensitive: false,
@@ -159,6 +160,15 @@
         items={itemsFiltered}
         {selectedIndex}
         on:clickedIndex={onClickedIndex} />
+    </div>
+    <!-- when svelte gets conditional slots
+           https://github.com/sveltejs/svelte/issues/5604
+         re-implement to remove the empty div.hidden.
+    --> 
+    <div class="{ footerText === null ? 'hidden': 'footer' }" slot="footer">
+      {#if footerText !== null }
+        {footerText}
+      {/if}
     </div>
   </PaletteContainer>
 </div>

--- a/src/PaletteContainer.svelte
+++ b/src/PaletteContainer.svelte
@@ -42,6 +42,14 @@
   .search-box {
     padding: 7px;
   }
+  :global(.footer) {
+   background-color: rgba(0, 0, 0, 0.33);
+   border-block-start: black ridge 2px;
+   color: #ddd;
+   font-size: smaller;
+   padding-block-start: 0.1em;
+   padding-inline: 0.5em;
+  }
   /* .search:focus {
   color: white;
 } */
@@ -55,6 +63,7 @@
       </div>
       <div>
         <slot name="items" />
+        <slot name="footer" />
       </div>
     </div>
   </div>

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ class CommandPal {
         placeholderText: this.options.placeholder || "What are you looking for?",
         hotkeysGlobal: this.options.hotkeysGlobal || false,
         hideButton: this.options.hideButton || false,
+        footerText: this.options.footerText ||  null,
       },
     });
     const ctx = this;


### PR DESCRIPTION
New CommandPal option footerText. If set to null (default) no footer is displayed. If set to a string the string is displayed.

The way I handle conditionally showing the footer is kind of ugly. Svelte doesn't have conditional slots. Once:

    https://github.com/sveltejs/svelte/issues/5604

is implemented, the whole mess can be cleanly rewritten.

I would have like to use :where(.footer) in the css for styling. But there are a lot of mobile browsers on caniuse that have unknown status even 2 years after their release.

Using :where would allow ".footer" in user's css to work. As it is you have to make ".footer" more specific using e.g. "#id .footer" or ".footer[slot=footer]".

README.md, and cp-advanced files updated to show/use.