### PR TITLE
bug: fix ESC, arrow keys not working on mobile

### DIFF
--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -26,7 +26,8 @@
   }
 
   function onKeyDown(e) {
-    const keyCode = e.code.toLowerCase();
+    let keyCode = e.key.toLowerCase();
+
     if (keyCode === "enter") {
       dispatch("enter", inputValue);
       onBlur();


### PR DESCRIPTION
This at east fixes keyboard keys ESC and arrow up/down on android with chrome using the Hacker's keyboard.

From:

   https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

e.code() has issues with mapping the proper keyboard layout. For this application with a physical keyboard and the keys being used I don't think it matters but, if we wanted to intercept Y on an QWERTY keyboard it would intercept Z on a QUERTZ layout.