### PR TITLE
able to exit from palette using 1 or more backspaces on empty search

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ const c = new CommandPal({
   placeholder: "Custom placeholder text...", //  Changes placeholder text of input
   debugOuput: false, // if true report debugging info to console
   hideButton: false, // if true, do not generate mobile button
+  backspaceCloseCount: 0, // this number of backspaces typed in an
+                          // empty search input will close, command-pal.
+                          // Allows closing with keyboard on mobile devices.
+                          // Default value of 0 prevents closing on backspace.
   commands: [
     // Commands go here
   ]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,7 @@
   export let placeholderText;
   export let hideButton;
   export let paletteId;
+  export let backspaceCloseCount;
 
   const optionsFuse = {
     isCaseSensitive: false,
@@ -146,6 +147,7 @@
     <div slot="search">
       <SearchField
         placeholderText={placeholderText}
+        backspaceCloseCount={backspaceCloseCount}
         show={showModal}
         bind:inputEl={searchField}
         on:closed={onClosed}

--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -59,7 +59,7 @@
       dispatch("arrowup");
     } else if (keyCode === "backspace" && backspaceCloseCount) {
       // empty input: undefined if just opened, if keys added/deleted is ''
-      if (inputValue === undefined || inputValue === '' ){
+      if (!inputValue){
 	currentBackspaceCount++
 	if (currentBackspaceCount >= backspaceCloseCount) {
 	  onBlur();

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,8 @@ class CommandPal {
         placeholderText: this.options.placeholder || "What are you looking for?",
         hotkeysGlobal: this.options.hotkeysGlobal || false,
         hideButton: this.options.hideButton || false,
+        // # of consecutive backspaces to exit. 0: don't exit on backspace.
+        backspaceCloseCount: this.options.backspaceCloseCount || 0
       },
     });
     const ctx = this;


### PR DESCRIPTION
On mobile, there is no good way to exit from the palette using the keyboard. Most mobile keyboards don't have ESC keys, or they are on a secondary keyboard layout. The backspace key however is usually available on the primary keyboard layout.

This patch adds the ability to configure the number of consecutive backspaces to exit the palette. The backspaces only count if the search input is empty. If the number of required backspaces is > 1, the number of remaining backspaces is shown if it is less than 5. This feedback is generated by a template string. i18n may be an issue. YAGNI says not to fix this now 8-) .

Docs updated no examples changed. Works in Firefox and Chrome mobile and desktop.

NOTE: this also patches the onKeyDown in SearchField to use e.key rather than e.code otherwise it doesn't work on mobile where it is most useful.