### PR TITLE
Make shift+backspace erase entire search input

### DIFF
--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -34,6 +34,8 @@
       dispatch("arrowdown");
     } else if (keyCode === "arrowup") {
       dispatch("arrowup");
+    } else if (keyCode === "backspace" && e.shiftKey) {
+     inputValue = "";
     } else if (keyCode === "escape") {
       onBlur();
     }


### PR DESCRIPTION
Rather than backspacing a bunch of times. Also it works from any position in the input.

This patch is arguable since the search terms should be short and hitting 4 or 5 backspaces isn't horrible. Also on some systems (windows) ctrl+backspace erases the previous word.

This needs documentation, but I am not sure where it should go in the README. Documenting the use of the return key to:

  accept the currently highlighted entry or
  close command-pal if there is no match

The use of up/down arrows to navigate through the list.

Also if the "close command-pal on (multiple) backspaces" patch is added, documenting that would be good as well.

NOTE: if this code is merged after the multiple backspaces code, the then clause for this code should reset the backup counter and clear the feedback box like the other cases. Also it needs to go before the backspace exit code in the if/then chain otherwise it will never be reached if exit with backspace is enabled.