### PR TITLE
disable autocapitalize on search input.

### DIFF
--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -82,6 +82,6 @@
   on:keydown={onKeyDown}
   on:input={onTextChanged}
   autocomplete="no"
-  autocapitalize="no"
+  autocapitalize="none"
   type="text"
   placeholder={placeholderText} />

--- a/src/SearchField.svelte
+++ b/src/SearchField.svelte
@@ -82,5 +82,6 @@
   on:keydown={onKeyDown}
   on:input={onTextChanged}
   autocomplete="no"
+  autocapitalize="no"
   type="text"
   placeholder={placeholderText} />


### PR DESCRIPTION
Mobile keyboard will often capitalize the first character. Stop that. It's unexpected for search.