### PR TITLE
Add scroll shadows to indicate more items available

### DIFF
--- a/src/CommandList.svelte
+++ b/src/CommandList.svelte
@@ -71,6 +71,19 @@
     font-family: monospace;
   }
   .items-list {
+    /* indicata ability to scroll with edge scroll shadow.
+       https://css-scroll-shadows.vercel.app */
+    background:
+	linear-gradient(#373737 33%, rgba(55,55,55, 0)),
+	linear-gradient(rgba(55,55,55, 0), #373737 66%) 0 100%,
+	radial-gradient(farthest-side at 50% 0, rgba(255,255,255, 0.5),
+			rgba(0,0,0,0)),
+	radial-gradient(farthest-side at 50% 100%, rgba(255,255,255, 0.5),
+			rgba(0,0,0,0)) 0 100%;
+    background-color: #373737;
+    background-repeat: no-repeat;
+    background-attachment: local, local, scroll, scroll;
+    background-size: 100% 72px, 100% 72px, 100% 24px, 100% 24px;
     overflow-y: auto;
     max-height: min(360px, 50vh);
     max-height: min(360px, 80dvh);


### PR DESCRIPTION
On android the scroll bar is narrow and difficult to see.

Add scroll shadows to the command list to indicate that there are more items available.

<img width="327" alt="image" src="https://user-images.githubusercontent.com/3751752/220175872-6fa29653-0775-47b4-991a-8b08c6f8ad25.png">

Note the white shadows/light showing at the top and bottom since the list can scroll to either side.
If we were at the bottom, only the top shadow/light would be shown.

CSS generated with: https://css-scroll-shadows.vercel.app

Ref: https://lea.verou.me/2012/04/background-attachment-local/
     https://css-tricks.com/books/greatest-css-tricks/scroll-shadows/